### PR TITLE
[fix]websocketのkey名修正

### DIFF
--- a/app/src/components/chat/MessageList.js
+++ b/app/src/components/chat/MessageList.js
@@ -140,7 +140,7 @@ const MessageList = () => {
         try {
             chatSocket.send(JSON.stringify({
                 'message': value,
-                'user': decoded.name
+                'send_user': decoded.name
             }));
         } catch (e) {
             console.log(e)


### PR DESCRIPTION
## 目的
websocketがリアルタイムで受信できていなかったため修正

## 概要
- websocketに送信するkey名が間違えていたので修正